### PR TITLE
Fix typos in tensor specs and test comment

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -14211,7 +14211,7 @@ def test_updater(mode, value_network_update_interval, device, dtype):
             assert upd.counter == i
             upd.step()
         assert upd.counter == 0
-        # test that a new update has occured
+        # test that a new update has occurred
         d1 = 0.0
         for key, source_val in upd._sources.items(True, True):
             if not isinstance(key, tuple):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1304,7 +1304,7 @@ class _LazyStackedMixin(Generic[T]):
                             return self
                         if dim_idx != self.dim:
                             raise RuntimeError(
-                                f"Indexing occured along dimension {dim_idx} but stacking was done along dim {self.dim}."
+                                f"Indexing occurred along dimension {dim_idx} but stacking was done along dim {self.dim}."
                             )
                         out = self._specs[item]
                         if isinstance(out, TensorSpec):


### PR DESCRIPTION
## Summary
- fix a typo in `_LazyStackedMixin` error message
- fix typo in test comment